### PR TITLE
feat: add poll, mergeSkipNullish, isNullish functions; add SpreadSkipNullish/Nullish types

### DIFF
--- a/docs/demo/async/poll.md
+++ b/docs/demo/async/poll.md
@@ -1,0 +1,18 @@
+[[[demo
+```ts
+import { poll } from 'parsnip-kit'
+
+const getList = () => {
+  return fetch('https://example.url.test/list').then((response) => {
+    response.json()
+    // ...
+  })
+}
+const polled = poll(getList, 1000)
+const pollResult = polled()
+
+// ...
+// Stop polling
+pollResult.stop()
+```
+]]]

--- a/docs/demo/object/mergeSkipNullish.md
+++ b/docs/demo/object/mergeSkipNullish.md
@@ -1,0 +1,11 @@
+[[[demo
+```ts
+import { mergeSkipNullish } from 'parsnip-kit'
+
+const obj1 = { a: 1, b: null, c: undefined }
+const obj2 = { b: 2, c: 3, d: null }
+const obj3 = { c: undefined, d: 4, e: 5 }
+
+mergeSkipNullish(obj1, obj2, obj3) // { a: 1, b: 2, c: 3, d: 4, e: 5 }
+```
+]]]

--- a/docs/demo/typed/isNullish.md
+++ b/docs/demo/typed/isNullish.md
@@ -1,0 +1,10 @@
+[[[demo
+```ts
+import { isNullish } from 'parsnip-kit'
+
+isNullish(undefined) // true
+isNullish(null) // true
+isNullish(NaN) // false
+isNullish(0) // false
+```
+]]]

--- a/docs/doc/async/poll.md
+++ b/docs/doc/async/poll.md
@@ -1,0 +1,115 @@
+# poll
+[[[desc poll
+  
+]]]
+[[[desc poll zh
+  传入返回 `Promise` 的函数 `func` 和等待间隔 `wait` ，返回一个函数，它以固定间隔轮询异步任务，支持可配置的重试和运行时控制。
+
+  可选参数 `options` 设置重试的配置，具体看[这里](#polloptions)。
+
+  函数返回一个控制轮询的对象，具体看[这里](#pollresult)。
+]]]
+[[[desc poll ja
+  `Promise` を返す関数 `func` と待機間隔 `wait` を渡し、固定間隔で非同期タスクをポーリングし、設定可能なリトライと実行時制御を提供する関数を返します。
+
+  オプション引数 `options` でリトライ設定を行います。詳細は[こちら](#polloptions)。
+
+  関数はポーリングを制御するオブジェクトを返します。詳細は[こちら](#pollresult)。
+]]]
+[[[version poll
+  
+]]]
+
+### Usage
+
+[[[demo]]]
+
+
+### API
+
+#### Type Parameter
+
+[[[template poll
+
+]]]
+[[[template poll zh
+T:函数 `func` 返回的 `Promise` 的`value` 类型
+]]]
+[[[template poll ja
+T：関数 `func` が返す `Promise` の `value` の型
+]]]
+#### Arguments
+
+[[[params poll
+
+]]]
+[[[params poll zh
+func: 要轮询的异步函数
+wait: 轮询间隔（毫秒）
+options: 轮询配置
+options.maxRetries: 失败时最大重试次数，轮询成功时内部重试次数计数就会被重置
+options.sequential: 等待上一次执行完成后再开始下一次轮询
+options.leading: 立即执行一次
+options.onSuccess: 成功时的回调
+options.onFailure: 失败时的回调
+]]]
+[[[params poll ja
+func: ポーリング対象の非同期関数
+wait: ポーリング間隔（ミリ秒）
+options: ポーリング設定
+options.maxRetries: 失敗時の最大リトライ回数。成功時にカウンターをリセット
+options.sequential: 前回の実行が完了するまで次回を待機
+options.leading: 直ちに 1 回実行
+options.onSuccess: 成功時のコールバック
+options.onFailure: 失敗時のコールバック
+]]]
+
+#### Returns
+
+[[[returns poll
+
+]]]
+
+# PollOptions
+      
+[[[desc PollOptions
+
+]]]
+[[[desc PollOptions zh
+`poll` 函数的参数 `options` 的类型。
+]]]
+[[[desc PollOptions ja
+`poll` 関数の `options` パラメーターの型。
+]]]
+
+[[[version PollOptions
+  
+]]]
+
+### Source
+
+[[[source PollOptions
+  
+]]]
+
+# PollResult
+      
+[[[desc PollResult
+
+]]]
+[[[desc PollResult zh
+`poll` 函数的返回值类型。
+]]]
+[[[desc PollResult ja
+`poll` 関数の戻り値の型。
+]]]
+
+[[[version PollResult
+  
+]]]
+
+### Source
+
+[[[source PollResult
+  
+]]]

--- a/docs/doc/async/retry.md
+++ b/docs/doc/async/retry.md
@@ -28,6 +28,9 @@
 [[[template retry zh
 T:函数`func`返回的`Promise`的`value`类型
 ]]]
+[[[template poll ja
+T：関数`func`が返す`Promise`の`value`の型
+]]]
 
 #### Arguments
 

--- a/docs/doc/common/types.md
+++ b/docs/doc/common/types.md
@@ -296,3 +296,45 @@
 [[[source DataUnit
   
 ]]]
+
+# Nullish
+[[[desc Nullish
+]]]
+[[[desc Nullish zh
+`Nullish` 类型表示值为 `null` 或 `undefined` 的类型。
+]]]
+[[[desc Nullish ja
+`Nullish` 型は、値が `null` または `undefined` の場合を表します。
+]]]
+
+[[[version Nullish
+  
+]]]
+
+### Source
+[[[source Nullish
+  
+]]]
+
+# SpreadSkipNullish
+[[[desc SpreadSkipNullish
+]]]
+[[[desc SpreadSkipNullish zh
+  从左到右合并多个类型，形成一个新的对象类型。
+
+  前面对象中非 `null` 或 `undefined` 的字段不会被后面的 `null` 或 `undefined` 的字段覆盖。
+]]]
+[[[desc SpreadSkipNullish ja
+  左から右に複数の型をマージして新しいオブジェクトの型を形成します。
+
+  先のオブジェクトの `null` または `undefined` でないフィールドは、後のオブジェクトの `null` または `undefined` のフィールドによって上書きされません。
+]]]
+
+[[[version SpreadSkipNullish
+  
+]]]
+
+### Source
+[[[source SpreadSkipNullish
+  
+]]]

--- a/docs/doc/object/mergeSkipNullish.md
+++ b/docs/doc/object/mergeSkipNullish.md
@@ -1,0 +1,74 @@
+# mergeSkipNullish
+[[[desc mergeSkipNullish
+  
+]]]
+[[[desc mergeSkipNullish zh
+  从左到右合并多个对象，形成一个新的对象。
+
+  前面对象中非 `null` 或 `undefined` 的字段不会被后面的 `null` 或 `undefined` 的字段覆盖。
+]]]
+[[[desc mergeSkipNullish ja
+  左から右に複数のオブジェクトをマージして新しいオブジェクトを形成します。
+
+  先のオブジェクトの `null` または `undefined` でないフィールドは、後のオブジェクトの `null` または `undefined` のフィールドによって上書きされません。
+]]]
+[[[version mergeSkipNullish
+  
+]]]
+
+### Usage
+
+[[[demo]]]
+
+
+### API
+
+#### Type Parameter
+
+[[[template mergeSkipNullish
+
+]]]
+[[[template mergeSkipNullish zh
+T: 要合并的对象的类型
+]]]
+[[[template mergeSkipNullish ja
+T: マージするオブジェクトの型
+]]]
+
+#### Arguments
+
+[[[params mergeSkipNullish
+
+]]]
+[[[params mergeSkipNullish zh
+objs: 要合并的对象
+]]]
+[[[params mergeSkipNullish ja
+objs: マージするオブジェクト
+]]]
+
+#### Returns
+
+[[[returns mergeSkipNullish
+
+]]]
+
+#### Type Definition 
+```ts
+{
+  <T extends object, U extends object>(
+    a: T | Nullish, b: U | Nullish
+  ): SpreadSkipNullish<T, U>
+  <T extends object, U extends object, V extends object>(
+    a: T | Nullish, b: U | Nullish, c: V | Nullish
+  ): SpreadSkipNullish<SpreadSkipNullish<T, U>, V>
+  <T extends object, U extends object, V extends object, W extends object>(
+    a: T | Nullish, b: U | Nullish, c: V | Nullish, d: W | Nullish
+  ): SpreadSkipNullish<SpreadSkipNullish<SpreadSkipNullish<T, U>, V>, W>
+  (...objs: any[]): any
+}
+```
+
+
+#### Reference
+[Nullish](../common/types#nullish) [SpreadSkipNullish](../common/types#spreadskipnullish)

--- a/docs/doc/typed/isNullish.md
+++ b/docs/doc/typed/isNullish.md
@@ -1,0 +1,38 @@
+# isNullish
+[[[desc isNullish
+  
+]]]
+[[[desc isNullish zh
+  检查入参是否为 `undefined` 或 `null`。
+]]]
+[[[desc isNullish ja
+  パラメーターが `undefined` または `null` かどうかを確認します。
+]]]
+[[[version isNullish
+  
+]]]
+
+### Usage
+
+[[[demo]]]
+
+
+### API
+
+#### Arguments
+
+[[[params isNullish
+
+]]]
+[[[params isNullish zh
+arg: 要检查的参数
+]]]
+[[[params isNullish ja
+arg: 検査するパラメーター
+]]]
+
+#### Returns
+
+[[[returns isNullish
+
+]]]

--- a/packages/__share__/console.ts
+++ b/packages/__share__/console.ts
@@ -1,0 +1,29 @@
+const isNotProdMode =
+  typeof process !== 'undefined' && process.env.NODE_ENV !== 'production'
+const projectName = 'Parsnip-Kit'
+
+export function logInfo(...message: any[]) {
+  if (isNotProdMode) {
+    console.log(`[${projectName}]`, ...message)
+  }
+}
+
+export function logWarn(...message: any[]) {
+  if (isNotProdMode) {
+    console.warn(`[${projectName}]`, ...message)
+  }
+}
+
+export function logError(...message: any[]) {
+  if (isNotProdMode) {
+    console.error(`[${projectName}]`, ...message)
+  }
+}
+
+export function throwError(message: string) {
+  throw new Error(`[${projectName}] ${message}`)
+}
+
+export function createError(message: string) {
+  return new Error(`[${projectName}] ${message}`)
+}

--- a/packages/__test__/main.test.ts
+++ b/packages/__test__/main.test.ts
@@ -9,7 +9,11 @@ describe('escapeRegExp', () => {
     const varSet = new Set<string>()
     const exports = Object.keys(files)
       .map(async (filename: string) => {
-        if (filename.includes('.test.ts') || filename === '../main.ts') {
+        if (
+          filename.includes('.test.ts') ||
+          filename === '../main.ts' ||
+          filename.includes('../__share__/')
+        ) {
           return
         }
         return files[filename]()

--- a/packages/async/__test__/poll.test.ts
+++ b/packages/async/__test__/poll.test.ts
@@ -1,0 +1,172 @@
+import { poll, PollOptions } from '../poll'
+import { vi, expect, describe, test, beforeEach } from 'vitest'
+
+const genMockOptions: <T>() => Required<PollOptions<T>> = () => ({
+  maxCalls: Infinity,
+  maxRetries: 3,
+  sequential: false,
+  leading: true,
+  onSuccess: vi.fn(),
+  onFailure: vi.fn()
+})
+
+describe('poll function', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('should execute the function with the correct arguments', async () => {
+    const mockAsyncFunction = vi.fn().mockImplementation(async () => {
+      return 'success'
+    })
+    const mockOptions = genMockOptions()
+    const args = ['arg1', 'arg2']
+    const pollResult = poll(mockAsyncFunction, 10, mockOptions)(...args)
+    await pollResult.stop()
+    expect(mockAsyncFunction).toHaveBeenCalledWith(...args)
+  })
+
+  test('should call onSuccess when the function resolves successfully', async () => {
+    const mockAsyncFunction = vi.fn().mockImplementation(async () => {
+      return 'success'
+    })
+    const mockOptions = genMockOptions()
+    const pollResult = poll(mockAsyncFunction, 10, mockOptions)()
+    await pollResult.stop()
+    expect(mockOptions.onSuccess).toHaveBeenCalledWith('success', 1)
+  })
+
+  test('should call onFailure when the function rejects', async () => {
+    const mockAsyncFunction = vi.fn().mockImplementation(async () => {
+      return 'success'
+    })
+    const mockOptions = genMockOptions()
+    mockAsyncFunction.mockRejectedValueOnce(new Error('mock error'))
+    const pollResult = poll(mockAsyncFunction, 10, mockOptions)()
+    await pollResult.stop()
+    expect(mockOptions.onFailure).toHaveBeenCalledWith(
+      new Error('mock error'),
+      1
+    )
+  })
+
+  test('should retry until maxRetries is reached', async () => {
+    const mockAsyncFunction = vi.fn().mockImplementation(async () => {
+      return 'success'
+    })
+    const mockOptions = genMockOptions()
+    mockAsyncFunction.mockRejectedValue(new Error('mock error'))
+    const pollResult = poll(mockAsyncFunction, 10, mockOptions)()
+    await new Promise((resolve) => setTimeout(resolve, 4000))
+    expect(mockAsyncFunction).toHaveBeenCalledTimes(mockOptions.maxRetries + 1)
+    expect(mockOptions.onFailure).toHaveBeenCalledTimes(
+      mockOptions.maxRetries + 1
+    )
+    pollResult.stop()
+  })
+
+  test('should throw an error when maxRetries is exceeded', async () => {
+    const mockAsyncFunction = vi.fn().mockImplementation(async () => {
+      return 'success'
+    })
+    const mockOptions = genMockOptions()
+    mockAsyncFunction.mockRejectedValue(new Error('mock error'))
+    const originalConsoleWarn = console.warn
+    console.warn = vi.fn()
+    const pollResult = poll(mockAsyncFunction, 10, mockOptions)()
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    expect(console.warn).toHaveBeenCalledTimes(1)
+    console.warn = originalConsoleWarn
+    pollResult.stop()
+  })
+
+  test('should execute sequentially when sequential is true', async () => {
+    const mockAsyncFunction = vi.fn().mockImplementation(async () => {
+      return new Promise((res) => {
+        setTimeout(() => {
+          res('success')
+        }, 100)
+      })
+    })
+    const mockOptions = genMockOptions()
+    mockOptions.sequential = true
+    const pollResult = poll(mockAsyncFunction, 10, mockOptions)()
+    await new Promise((resolve) => setTimeout(resolve, 250))
+    expect(mockAsyncFunction).toHaveBeenCalledTimes(3)
+    mockOptions.sequential = false
+    pollResult.stop()
+  })
+
+  test('should not execute immediately when leading is false', async () => {
+    const mockAsyncFunction = vi.fn().mockImplementation(async () => {
+      return 'success'
+    })
+    const mockOptions = genMockOptions()
+    mockOptions.leading = false
+    mockAsyncFunction.mockResolvedValueOnce('success')
+    const pollResult = poll(mockAsyncFunction, 20, mockOptions)()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(mockAsyncFunction).not.toHaveBeenCalled()
+    pollResult.stop()
+    mockOptions.leading = true // Reset for other tests
+  })
+
+  test('should stop the poll when stop is called', async () => {
+    const mockAsyncFunction = vi.fn().mockImplementation(async () => {
+      return 'success'
+    })
+    const mockOptions = genMockOptions()
+    const pollResult = poll(mockAsyncFunction, 15, mockOptions)()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    pollResult.stop()
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    expect(mockAsyncFunction).toHaveBeenCalledTimes(1)
+    expect(pollResult.isRunning()).toBe(false)
+  })
+
+  test('should start the poll again when start is called', async () => {
+    const mockAsyncFunction = vi.fn().mockImplementation(async () => {
+      return 'success'
+    })
+    const mockOptions = genMockOptions()
+
+    const pollResult = poll(mockAsyncFunction, 15, mockOptions)()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    pollResult.stop()
+    expect(pollResult.isRunning()).toBe(false)
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    expect(mockAsyncFunction).toHaveBeenCalledTimes(1)
+    pollResult.start()
+    expect(pollResult.isRunning()).toBe(true)
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    expect(mockAsyncFunction).toHaveBeenCalledTimes(3)
+  })
+
+  test('should not start the poll if it is already running', async () => {
+    const mockAsyncFunction = vi.fn().mockImplementation(async () => {
+      return 'success'
+    })
+    const mockOptions = genMockOptions()
+
+    expect(mockAsyncFunction).toHaveBeenCalledTimes(0)
+    const pollResult = poll(mockAsyncFunction, 15, mockOptions)()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(pollResult.isRunning()).toBe(true)
+    pollResult.start()
+    expect(mockAsyncFunction).toHaveBeenCalledTimes(1)
+    pollResult.stop()
+  })
+
+  test('should handle maxCalls correctly', async () => {
+    const mockAsyncFunction = vi.fn().mockImplementation(async () => {
+      return 'success'
+    })
+    const mockOptions = genMockOptions()
+    mockOptions.maxCalls = 2
+    const pollResult = poll(mockAsyncFunction, 10, mockOptions)()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(mockAsyncFunction).toHaveBeenCalledTimes(2)
+    expect(pollResult.isRunning()).toBe(false)
+    mockOptions.maxCalls = Infinity // Reset for other tests
+  })
+})

--- a/packages/async/poll.ts
+++ b/packages/async/poll.ts
@@ -1,0 +1,143 @@
+/**
+ * Provide a function `func` that returns a `Promise` and a wait interval `wait`, and return a function that polls the asynchronous task at a fixed interval, supporting configurable retries and runtime control.
+ *
+ * Optional parameter options configures retry behavior; see [here](#polloptions).
+ *
+ * The function returns an object to control polling; see [here](#pollresult).
+ *
+ * @template T Type of the `value` returned by the `Promise` of function `func`
+ * @param {(...args: any[]) => Promise<T>} func The async function to poll
+ * @param {number} wait Interval in milliseconds between polls
+ * @param {PollOptions<T>} [options] Polling configuration
+ * @param {number} [options.maxRetries=3] Max retry count on failure; Reset counter on success
+ * @param {number} [options.maxCalls=Infinity] Maximum number of calls of `func`
+ * @param {boolean} [options.sequential=false] Wait for previous run before next poll
+ * @param {boolean} [options.leading=true] Execute once immediately
+ * @param {(result: T, retries: number) => void} [options.onSuccess] Callback on success
+ * @param {(error: any, retries: number) => void} [options.onFailure] Callback on failure
+ * @returns {(...args: Parameters<typeof func>) => PollResult}
+ * @version 0.0.4
+ */
+
+import { logWarn } from '../__share__/console'
+
+export function poll<T>(
+  func: (...args: any[]) => Promise<T>,
+  wait: number,
+  options?: PollOptions<T>
+) {
+  const {
+    maxRetries = 3,
+    maxCalls = Infinity,
+    sequential = false,
+    leading = true,
+    onSuccess = () => {},
+    onFailure = () => {}
+  } = options || {}
+
+  function executeWithPoll(this: unknown, ...args: Parameters<typeof func>) {
+    let timer: number | undefined
+    let retries = 0
+    let calls = 0
+    let stopped = false
+
+    const executeTask = async () => {
+      calls++
+      try {
+        const result = await func.apply(this, args)
+        onSuccess(result, retries + 1)
+        retries = 0 // Reset retries on success
+      } catch (error) {
+        retries++
+        onFailure(error, retries)
+        if (retries > maxRetries) {
+          stop()
+          logWarn(`Max retries exceeded: ${maxRetries}. Last error:`, error)
+        }
+      }
+
+      if (calls >= maxCalls) {
+        stop()
+        logWarn(`Max calls exceeded: ${maxCalls}. Stopping polling.`)
+      }
+    }
+
+    const runPoll = async () => {
+      timer = setTimeout(async () => {
+        if (!stopped) {
+          if (sequential) {
+            await executeTask()
+            runPoll()
+          } else {
+            runPoll()
+            executeTask()
+          }
+        }
+      }, wait)
+    }
+
+    const init = async () => {
+      if (leading) {
+        if (sequential) {
+          await executeTask()
+        } else {
+          executeTask()
+        }
+      }
+      runPoll()
+    }
+
+    const stop = () => {
+      stopped = true
+      if (timer) {
+        clearTimeout(timer)
+        timer = undefined
+      }
+    }
+
+    init()
+
+    return {
+      stop,
+      isRunning: () => !stopped,
+      start: () => {
+        if (stopped) {
+          retries = 0
+          calls = 0
+          stopped = false
+          init()
+        }
+      }
+    }
+  }
+
+  return function (
+    this: unknown,
+    ...args: Parameters<typeof func>
+  ): PollResult {
+    return executeWithPoll.apply(this, args)
+  }
+}
+
+/**
+ * The type of `options` parameter of the `poll` function.
+ * @version 0.0.4
+ */
+export interface PollOptions<T> {
+  maxRetries?: number
+  sequential?: boolean
+  leading?: boolean
+  maxCalls?: number
+  onSuccess?: (result: T, retries: number) => void
+  onFailure?: (error: any, retries: number) => void
+}
+
+/**
+ * The return of the `poll` function.
+ * @version 0.0.4
+ */
+export interface PollResult {
+  stop: () => void
+  start: () => void
+  isRunning: () => boolean
+}

--- a/packages/async/retry.ts
+++ b/packages/async/retry.ts
@@ -1,16 +1,18 @@
+import { createError } from '../__share__/console'
+
 /**
  * Accepts a function `func` that returns a `Promise` and a `maxRetries` parameter (defaulting to 3), returning a function that retries the invocation of the given function upon failure.
  *
  * The optional parameter `options` sets up the retry configuration, details of which can be found [here](#retryoptions).
  *
- * @template {} T  Type of the `value` returned by the `Promise` of function `func`.
- * @param {(...args: any[]) => Promise<T>} func The asynchronous task function to be retried must return a Promise.
+ * @template {} T Type of the `value` returned by the `Promise` of function `func`
+ * @param {(...args: any[]) => Promise<T>} func The asynchronous task function to be retried must return a `Promise`
  * @param {number} [maxRetries=3] Maximum number of retries
- * @param {RetryOptions} [options] Configuration options
+ * @param {RetryOptions<T>} [options] Configuration options
  * @param {number} [options.delay=300]  Initial delay for retries (in milliseconds)
  * @param {number} [options.delayFactor=2]  Delay increment factor (the delay is multiplied by this value for each retry)
  * @param {(error: any, attempts: number) => boolean} [options.shouldRetry]  Callback function to determine whether to retry
- * @param {(result: any, attempts: number) => any} [options.onSuccess] Callback function when the task is successful
+ * @param {(result: T, attempts: number) => any} [options.onSuccess] Callback function when the task is successful
  * @param {(result: any, attempts: number) => any} [options.onFailure] Callback function when the task fails
  * @returns {(...args: Parameters<typeof func>) => Promise<PromiseSettledResult<Awaited<T>>>}
  * @version 0.0.1
@@ -18,30 +20,26 @@
 export function retry<T>(
   func: (...args: any[]) => Promise<T>,
   maxRetries: number = 3,
-  options?: RetryOptions
+  options?: RetryOptions<T>
 ) {
-  const defaultOptions: Required<RetryOptions> = {
-    delay: 300,
-    delayFactor: 2,
-    shouldRetry: (error: any, attempts: number) => true, // eslint-disable-line
-    onSuccess: () => {},
-    onFailure: () => {}
-  }
-
-  const config = { ...defaultOptions, ...options }
+  const {
+    delay = 300,
+    delayFactor = 2,
+    shouldRetry = (error: any, attempts: number) => true, // eslint-disable-line
+    onSuccess = () => {},
+    onFailure = () => {}
+  } = options || {}
 
   async function executeWithRetry(
-    this: ThisParameterType<T>,
+    this: unknown,
     ...args: Parameters<typeof func>
   ): Promise<PromiseSettledResult<Awaited<T>>> {
     let attempts = 0
 
     const executeTask = async () => {
       try {
-        const result = await Promise.resolve().then(() =>
-          Promise.resolve(func.apply(this, args))
-        )
-        config.onSuccess(result, attempts + 1)
+        const result = await func.apply(this, args)
+        onSuccess(result, attempts + 1)
         return {
           value: result,
           status: 'fulfilled' as const
@@ -49,21 +47,25 @@ export function retry<T>(
       } catch (error) {
         attempts += 1
         if (attempts > maxRetries) {
-          config.onFailure(error, attempts)
+          onFailure(error, attempts)
           return {
-            reason: [error, new Error('Max retries exceeded')],
+            reason: [error, createError('Max retries exceeded')],
             status: 'rejected' as const
           }
         }
 
-        if (config.shouldRetry(error, attempts)) {
-          const delay = config.delay * Math.pow(config.delayFactor, attempts)
-          await new Promise((resolve) => setTimeout(resolve, delay))
+        if (shouldRetry(error, attempts)) {
+          onFailure(error, attempts)
+          const currentDelay = delay * Math.pow(delayFactor, attempts)
+          await new Promise((resolve) => setTimeout(resolve, currentDelay))
           return executeTask()
         } else {
-          config.onFailure(error, attempts)
+          onFailure(error, attempts)
           return {
-            reason: [error, new Error('Retry canceled by options.shouldRetry')],
+            reason: [
+              error,
+              createError('Retry canceled by options.shouldRetry')
+            ],
             status: 'rejected' as const
           }
         }
@@ -74,7 +76,7 @@ export function retry<T>(
   }
 
   return function (
-    this: ThisParameterType<T>,
+    this: unknown,
     ...args: Parameters<typeof func>
   ): Promise<PromiseSettledResult<Awaited<T>>> {
     return executeWithRetry.apply(this, args)
@@ -85,10 +87,10 @@ export function retry<T>(
  * The `options` parameter of the `retry` function.
  * @version 0.0.1
  */
-export interface RetryOptions {
+export interface RetryOptions<T> {
   delay?: number
   delayFactor?: number
   shouldRetry?: (error: any, attempts: number) => boolean
-  onSuccess?: (result: any, attempts: number) => any
-  onFailure?: (error: any, attempts: number) => any
+  onSuccess?: (result: T, attempts: number) => void
+  onFailure?: (error: any, attempts: number) => void
 }

--- a/packages/common/types.ts
+++ b/packages/common/types.ts
@@ -180,3 +180,29 @@ export type DataUnit =
   | 'EB'
   | 'ZB'
   | 'YB'
+
+/**
+ * `Nullish` type represents values that are either `null` or `undefined`.
+ * @version 0.0.4
+ */
+export type Nullish = undefined | null
+
+/**
+ * Merge multiple types from left to right to form a new object type.
+ *
+ * Fields that are not `null` or `undefined` in the preceding objects will not be overwritten by `null` or `undefined` fields from the subsequent objects.
+ * @version 0.0.4
+ */
+export type SpreadSkipNullish<T, U> = {
+  [K in keyof T | keyof U]: K extends keyof T
+    ? K extends keyof U
+      ? T[K] extends Nullish
+        ? U[K]
+        : U[K] extends Nullish
+          ? T[K]
+          : U[K]
+      : T[K]
+    : K extends keyof U
+      ? U[K]
+      : never
+}

--- a/packages/main.ts
+++ b/packages/main.ts
@@ -32,6 +32,7 @@ export { isNanValue } from './typed/isNanValue'
 export { isInt } from './typed/isInt'
 export { isFloat } from './typed/isFloat'
 export { getTypeTag } from './typed/getTypeTag'
+export { isNullish } from './typed/isNullish'
 
 export { getByPath } from './object/getByPath'
 export { setByPath } from './object/setByPath'
@@ -48,6 +49,7 @@ export { isEqualStrict } from './object/isEqualStrict'
 export { unzipToArrays } from './object/unzipToArrays'
 export { objectToPairs } from './object/objectToPairs'
 export { splitToArrays } from './object/splitToArrays'
+export { mergeSkipNullish } from './object/mergeSkipNullish'
 
 export { difference } from './array/difference'
 export { intersection } from './array/intersection'
@@ -105,6 +107,8 @@ export { concurrent } from './async/concurrent'
 export { sequential } from './async/sequential'
 export { retry } from './async/retry'
 export type { RetryOptions } from './async/retry'
+export { poll } from './async/poll'
+export type { PollOptions, PollResult } from './async/poll'
 
 export type {
   PrimitiveType,
@@ -123,7 +127,9 @@ export type {
   MappedTypeByKeyOrIndex,
   DeepMappedTypeByKeyOrIndex,
   DataUnit,
-  PseudoArray
+  PseudoArray,
+  Nullish,
+  SpreadSkipNullish
 } from './common/types'
 
 export {

--- a/packages/object/__test__/mergeNonNullish.test.ts
+++ b/packages/object/__test__/mergeNonNullish.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { mergeSkipNullish } from '../mergeSkipNullish' // 替换为你的文件路径
+
+describe('mergeSkipNullish', () => {
+  it('should merge objects correctly', () => {
+    const obj1 = { a: 1, b: null, c: undefined }
+    const obj2 = { b: 2, c: 3, d: 4 }
+    const obj3 = null
+    const obj4 = { a: 5, e: 6 }
+
+    const result = mergeSkipNullish(obj1, obj2, obj3, obj4)
+    expect(result).toEqual({ a: 5, b: 2, c: 3, d: 4, e: 6 })
+  })
+
+  it('should handle empty objects', () => {
+    const obj1 = {}
+    const obj2 = { a: 1 }
+    const obj3 = {}
+
+    const result = mergeSkipNullish(obj1, obj2, obj3)
+    expect(result).toEqual({ a: 1 })
+  })
+
+  it('should handle all nullish values', () => {
+    const obj1 = null
+    const obj2 = undefined
+    const obj3 = null
+
+    const result = mergeSkipNullish(obj1, obj2, obj3)
+    expect(result).toEqual({})
+  })
+
+  it('should handle mixed types correctly', () => {
+    const obj1 = { a: 1, b: 'string', c: true }
+    const obj2 = { a: null, b: 2564, c: false, d: 10 }
+    const obj3 = { a: 2, b: 'new string', c: null, d: undefined }
+
+    const result = mergeSkipNullish(obj1, obj2, obj3)
+    expect(result).toEqual({ a: 2, b: 'new string', c: false, d: 10 })
+  })
+
+  it('nullish field can be overwrote by post nullish field', () => {
+    const obj1 = { a: 1, b: null, c: undefined }
+    const obj2 = { b: undefined, c: null }
+
+    const result = mergeSkipNullish(obj1, obj2)
+    expect(result).toEqual({ a: 1, b: undefined, c: null })
+  })
+
+  it('not nullish field cannot be overwrote by post nullish field', () => {
+    const obj1 = { a: 1 }
+    const obj2 = { a: null }
+
+    const result = mergeSkipNullish(obj1, obj2)
+    expect(result).toEqual({ a: 1 })
+  })
+})

--- a/packages/object/mergeSkipNullish.ts
+++ b/packages/object/mergeSkipNullish.ts
@@ -1,0 +1,67 @@
+import { Nullish } from '../common/types'
+import { isNullish } from '../typed/isNullish'
+
+/**
+ * Merge multiple objects from left to right to form a new object.
+ *
+ * Fields that are not `null` or `undefined` in the preceding objects will not be overwritten by `null` or `undefined` fields from the subsequent objects.
+ *
+ * @template {extends object} T The type of the objects to merge
+ * @param {(T | Nullish)[]} ...objs The objects to merge
+ * @returns {T}
+ * @version 0.0.4
+ */
+function mergeSkipNullish<T extends object, U extends object>(
+  a: T | Nullish,
+  b: U | Nullish
+): SpreadSkipNullish<T, U>
+function mergeSkipNullish<T extends object, U extends object, V extends object>(
+  a: T | Nullish,
+  b: U | Nullish,
+  c: V | Nullish
+): SpreadSkipNullish<SpreadSkipNullish<T, U>, V>
+function mergeSkipNullish<
+  T extends object,
+  U extends object,
+  V extends object,
+  W extends object
+>(
+  a: T | Nullish,
+  b: U | Nullish,
+  c: V | Nullish,
+  d: W | Nullish
+): SpreadSkipNullish<SpreadSkipNullish<SpreadSkipNullish<T, U>, V>, W>
+function mergeSkipNullish(...objs: any[]): any
+function mergeSkipNullish(...objs: any[]): any {
+  return objs.reduce((acc, obj) => {
+    if (isNullish(obj)) {
+      return acc
+    }
+    const keys = Object.keys(obj)
+    for (const key of keys) {
+      const currentValue = acc![key]
+      const newValue = obj[key]
+
+      if (isNullish(currentValue) || !isNullish(newValue)) {
+        acc![key] = newValue
+      }
+    }
+    return acc
+  }, {})
+}
+
+export { mergeSkipNullish }
+
+type SpreadSkipNullish<T, U> = {
+  [K in keyof T | keyof U]: K extends keyof T
+    ? K extends keyof U
+      ? T[K] extends Nullish
+        ? U[K]
+        : U[K] extends Nullish
+          ? T[K]
+          : U[K]
+      : T[K]
+    : K extends keyof U
+      ? U[K]
+      : never
+}

--- a/packages/typed/__test__/typeCheck.test.ts
+++ b/packages/typed/__test__/typeCheck.test.ts
@@ -10,8 +10,16 @@ import { isBigInt } from '../isBigInt'
 import { isPrimitive } from '../isPrimitive'
 import { getTypeTag } from '../getTypeTag'
 import { isArray } from '../isArray'
+import { isNullish } from '../isNullish'
 
 describe('normal type', () => {
+  test('isNullish', () => {
+    expect(isNullish(null)).eq(true)
+    expect(isNullish({})).eq(false)
+    expect(isNullish(undefined)).eq(true)
+    expect(isNullish(NaN)).eq(false)
+    expect(isNullish(0)).eq(false)
+  })
   test('isString', () => {
     expect(isString('test')).eq(true)
     expect(isString(new String('test'))).eq(true)

--- a/packages/typed/isNullish.ts
+++ b/packages/typed/isNullish.ts
@@ -1,0 +1,12 @@
+import { Nullish } from '../common/types'
+
+/**
+ * Check if the input parameter is a `undefined` or `null`.
+ * @param {any} arg Parameters to check
+ * @returns {boolean}
+ * @version 0.0.4
+ */
+
+export function isNullish(arg): arg is Nullish {
+  return arg === null || arg === undefined
+}

--- a/script/jsdoc2Md.js
+++ b/script/jsdoc2Md.js
@@ -79,7 +79,7 @@ function generateMD(func) {
   } = func
 
   const descReg = new RegExp(
-    `\\[\\[\\[desc ${functionName}([\\d\\D]*?)\\]\\]\\]`,
+    `\\[\\[\\[desc ${functionName}[ \\n]{1}([\\d\\D]*?)\\]\\]\\]`,
     'g'
   )
   templateFile = transitParagraph(
@@ -90,7 +90,7 @@ function generateMD(func) {
   )
 
   const versionReg = new RegExp(
-    `\\[\\[\\[version ${functionName}([\\d\\D]*?)\\]\\]\\]`,
+    `\\[\\[\\[version ${functionName}[ \\n]{1}([\\d\\D]*?)\\]\\]\\]`,
     'g'
   )
   templateFile = transitParagraph(templateFile, versionReg, lang, () =>
@@ -112,7 +112,7 @@ function generateMD(func) {
   })
 
   const templateReg = new RegExp(
-    `\\[\\[\\[template ${functionName}([\\d\\D]*?)\\]\\]\\]`,
+    `\\[\\[\\[template ${functionName}[ \\n]{1}([\\d\\D]*?)\\]\\]\\]`,
     'g'
   )
   templateFile = transitParagraph(
@@ -149,7 +149,7 @@ function generateMD(func) {
   )
 
   const paramsReg = new RegExp(
-    `\\[\\[\\[params ${functionName}([\\d\\D]*?)\\]\\]\\]`,
+    `\\[\\[\\[params ${functionName}[ \\n]{1}([\\d\\D]*?)\\]\\]\\]`,
     'g'
   )
   templateFile = transitParagraph(
@@ -188,7 +188,7 @@ function generateMD(func) {
   )
 
   const returnsReg = new RegExp(
-    `\\[\\[\\[returns ${functionName}([\\d\\D]*?)\\]\\]\\]`,
+    `\\[\\[\\[returns ${functionName}[ \\n]{1}([\\d\\D]*?)\\]\\]\\]`,
     'g'
   )
   templateFile = transitParagraph(templateFile, returnsReg, lang, () => {
@@ -198,7 +198,7 @@ function generateMD(func) {
   })
 
   const sourceReg = new RegExp(
-    `\\[\\[\\[source ${functionName}([\\d\\D]*?)\\]\\]\\]`,
+    `\\[\\[\\[source ${functionName}[ \\n]{1}([\\d\\D]*?)\\]\\]\\]`,
     'g'
   )
   templateFile = transitParagraph(templateFile, sourceReg, lang, () => {

--- a/wiki/.vitepress/theme/custom.css
+++ b/wiki/.vitepress/theme/custom.css
@@ -20,10 +20,30 @@ img[alt="Static Badge"] {
     position: fixed;
     right: 24px;
     z-index: 114514;
+    height: 73vh;
+    overflow: auto;
     font-size: 14px;
   }
 }
 .table-of-contents ul {
   list-style-type: none;
   padding-left: 14px;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+  background-color: #F5F5F5;
+}
+
+::-webkit-scrollbar-track {
+  -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.05);
+  border-radius: 10px;
+  background-color: #F5F5F5;
+}
+
+::-webkit-scrollbar-thumb {
+  border-radius: 10px;
+  -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,.03);
+  background-color: rgba(0,0,0,.1);
 }


### PR DESCRIPTION
# feat: add poll, mergeSkipNullish, isNullish functions; add SpreadSkipNullish/Nullish types

## Features
- Add `poll` function: utility for polling asynchronous tasks with interval, retry, sequential, and callback support.
- Add `mergeSkipNullish` function: merges objects from left to right, skipping overwriting of non-nullish fields with null or undefined values.
- Add `isNullish` function: checks if a value is `null` or `undefined`.
- Add new types: `SpreadSkipNullish` and `Nullish` for advanced type support.

## Other Changes
- `retry` function: internal `this` binding is now fixed.
- `retry` function: options merging no longer uses object spread, improving performance.
- Docs: fix right-side table of contents (TOC) with max height and scroll enabled for better navigation.
- Add unified functions for logging and error throwing.
- Fix: resolved a bug where multi-language doc entries with the same prefix were incorrectly cleared during doc generation.

## Breaking Changes
- `retry` function:
  - `onFailure` is now called on every failure (was not always called before).
  - The user function is no longer wrapped in an extra Promise.