### PR TITLE
feat: Add flattenObject function and related utility types; fix poll …

### DIFF
--- a/docs/demo/object/flattenObject.md
+++ b/docs/demo/object/flattenObject.md
@@ -1,0 +1,31 @@
+[[[demo
+```ts
+import { flattenObject } from 'parsnip-kit'
+
+const input0 = {
+  a: [1, 2, { b: 3 }],
+  c: {
+    d: [4, 5, { e: 6 }]
+  }
+}
+flattenObject(input0)
+// {
+//   'a[0]': 1,
+//   'a[1]': 2,
+//   'a[2].b': 3,
+//   'c.d[0]': 4,
+//   'c.d[1]': 5,
+//   'c.d[2].e': 6
+// }
+
+const input1 = {
+  a: {},
+  b: [],
+  c: {
+    d: {},
+    e: []
+  }
+}
+flattenObject(input1) // {}
+```
+]]]

--- a/docs/doc/common/types.md
+++ b/docs/doc/common/types.md
@@ -338,3 +338,129 @@
 [[[source SpreadSkipNullish
   
 ]]]
+
+# IsAny
+[[[desc IsAny
+]]]
+[[[desc IsAny zh
+`IsAny` 类型用于判断一个类型是否为 `any`。
+如果 `T` 是 `any`，则结果为 `true`，否则为 `false`。
+]]]
+[[[desc IsAny ja
+`IsAny` 型は、型が `any` かどうかを判断するために使用されます。
+`T` が `any` の場合、結果は `true` となり、そうでない場合は `false` となります。
+]]]
+[[[version IsAny
+]]]
+### Source
+[[[source IsAny
+]]]
+
+# ArrayIndexes
+[[[desc ArrayIndexes
+]]]
+[[[desc ArrayIndexes zh
+`ArrayIndexes` 类型用于获取数组中元素的索引（不包括数组的通用属性，如 `length`）。
+]]]
+[[[desc ArrayIndexes ja
+`ArrayIndexes` 型は、配列の要素のインデックスを取得するために使用されます（配列の一般的なプロパティ、例えば `length` は除きます）。
+]]]
+[[[version ArrayIndexes
+]]]
+### Source
+[[[source ArrayIndexes
+]]]
+
+# FieldPathComponent
+[[[desc FieldPathComponent
+]]]
+[[[desc FieldPathComponent zh
+`FieldPathComponent` 类型用于生成字段路径组件。
+如果 `Str` 是数字或数字字符串，生成如 `'[1]'` 的路径；如果是字符串，生成如 `'a'` 的路径。
+根据后续是普通对象还是数组，决定是否添加 `'.'` 作为结尾。
+]]]
+[[[desc FieldPathComponent ja
+`FieldPathComponent` 型は、フィールドのパスコンポーネントを生成するために使用されます。
+`Str` が数字または数値文字列の場合、`'[1]'` のようなパスを生成し、文字列の場合には `'a'` のようなパスを生成します。
+次の型が普通のオブジェクトか配列かによって、最後に `'.'` を追加するかどうかが決まります。
+]]]
+[[[version FieldPathComponent
+]]]
+### Source
+[[[source FieldPathComponent
+]]]
+
+# FlattenArrayObject
+[[[desc FlattenArrayObject
+]]]
+[[[desc FlattenArrayObject zh
+`FlattenArrayObject` 类型用于将数组中的对象扁平化为联合类型。它会递归地处理数组中的每个元素，根据元素的类型（对象或数组）继续扁平化。
+]]]
+[[[desc FlattenArrayObject ja
+`FlattenArrayObject` 型は、配列内のオブジェクトを連合型にフラット化するために使用されます。これは、配列内の各要素を再帰的に処理し、要素の型（オブジェクトまたは配列）に応じてフラット化を続けます。
+]]]
+[[[version FlattenArrayObject
+]]]
+### Source
+[[[source FlattenArrayObject
+]]]
+
+# FlattenObject
+[[[desc FlattenObject
+]]]
+[[[desc FlattenObject zh
+`FlattenObject` 类型用于将对象扁平化为联合类型。它会递归地处理对象的每个字段，根据字段的类型（对象或数组）继续扁平化。
+]]]
+[[[desc FlattenObject ja
+`FlattenObject` 型は、オブジェクトを連合型にフラット化するために使用されます。これは、オブジェクトの各フィールドを再帰的に処理し、フィールドの型（オブジェクトまたは配列）に応じてフラット化を続けます。
+]]]
+[[[version FlattenObject
+]]]
+### Source
+[[[source FlattenObject
+]]]
+
+# UnionToIntersection
+[[[desc UnionToIntersection
+]]]
+[[[desc UnionToIntersection zh
+`UnionToIntersection` 类型用于将联合类型转换为交叉类型。例如，`A | B` 会被转换为 `A & B`。
+]]]
+[[[desc UnionToIntersection ja
+`UnionToIntersection` 型は、連合型を交叉型に変換するために使用されます。例えば、`A | B` は `A & B` に変換されます。
+]]]
+[[[version UnionToIntersection
+]]]
+### Source
+[[[source UnionToIntersection
+]]]
+
+# IntersectionToObject
+[[[desc IntersectionToObject
+]]]
+[[[desc IntersectionToObject zh
+`IntersectionToObject` 类型用于将交叉类型转换为对象类型。例如，`A & B` 会被转换为 `{ [K in keyof (A & B)]: (A & B)[K] }`。
+]]]
+[[[desc IntersectionToObject ja
+`IntersectionToObject` 型は、交叉型をオブジェクト型に変換するために使用されます。例えば、`A & B` は `{ [K in keyof (A & B)]: (A & B)[K] }` に変換されます。
+]]]
+[[[version IntersectionToObject
+]]]
+### Source
+[[[source IntersectionToObject
+]]]
+
+# FlattenNestObject
+[[[desc FlattenNestObject
+]]]
+[[[desc FlattenNestObject zh
+`FlattenNestObject` 类型用于将嵌套对象扁平化为新的对象类型。它通过 `FlattenObject` 将对象扁平化为联合类型，然后通过 `UnionToIntersection`将联合类型转换为交叉类型，最终通过 `IntersectionToObject` 将交叉类型转换为对象类型。
+]]]
+[[[desc FlattenNestObject ja
+`FlattenNestObject` 型は、ネストされたオブジェクトを新しいオブジェクト型にフラット化するために使用されます。まず、`FlattenObject` を使用してオブジェクトを連合型にフラット化し、次に `UnionToIntersection` を使用して連合型を交叉型に変換し、最後に `IntersectionToObject` を使用して交叉型をオブジェクト型に変換します。
+]]]
+[[[version FlattenNestObject
+]]]
+### Source
+[[[source FlattenNestObject
+]]]

--- a/docs/doc/object/flattenObject.md
+++ b/docs/doc/object/flattenObject.md
@@ -1,0 +1,53 @@
+# flattenObject
+[[[desc flattenObject
+  
+]]]
+[[[desc flattenObject zh
+  接收一个对象`obj`，深度优先遍历嵌套对象的可枚举属性，返回扁平化后的新对象，key 为字段路径字符串，value 为对应的值。
+]]]
+[[[desc flattenObject ja
+  オブジェクト`obj`を受け取り、ネストされたオブジェクトの列挙可能なプロパティを深さ優先でトラバースし、フィールドパス文字列をキーとし、対応する値を値とする平坦化された新しいオブジェクトを返します。
+]]]
+[[[version flattenObject
+  
+]]]
+
+### Usage
+
+[[[demo]]]
+
+
+### API
+
+#### Type Parameter
+
+[[[template flattenObject
+
+]]]
+[[[template flattenObject zh
+T: 被扁平化对象的类型
+]]]
+[[[template flattenObject ja
+T: 平坦化されるオブジェクトの型
+]]]
+
+#### Arguments
+
+[[[params flattenObject
+]]]
+[[[params flattenObject zh
+obj: 扁平化的对象
+]]]
+[[[params flattenObject ja
+obj: 平坦化されるオブジェクト
+]]]
+
+#### Returns
+
+[[[returns flattenObject
+
+]]]
+
+
+#### Reference
+[FlattenNestObject](../common/types#flattennestobject) 

--- a/packages/async/__test__/poll.test.ts
+++ b/packages/async/__test__/poll.test.ts
@@ -90,8 +90,8 @@ describe('poll function', () => {
     })
     const mockOptions = genMockOptions()
     mockOptions.sequential = true
-    const pollResult = poll(mockAsyncFunction, 10, mockOptions)()
-    await new Promise((resolve) => setTimeout(resolve, 250))
+    const pollResult = poll(mockAsyncFunction, 100, mockOptions)()
+    await new Promise((resolve) => setTimeout(resolve, 500))
     expect(mockAsyncFunction).toHaveBeenCalledTimes(3)
     mockOptions.sequential = false
     pollResult.stop()
@@ -149,7 +149,7 @@ describe('poll function', () => {
     const mockOptions = genMockOptions()
 
     expect(mockAsyncFunction).toHaveBeenCalledTimes(0)
-    const pollResult = poll(mockAsyncFunction, 15, mockOptions)()
+    const pollResult = poll(mockAsyncFunction, 100, mockOptions)()
     await new Promise((resolve) => setTimeout(resolve, 10))
     expect(pollResult.isRunning()).toBe(true)
     pollResult.start()

--- a/packages/main.ts
+++ b/packages/main.ts
@@ -50,6 +50,7 @@ export { unzipToArrays } from './object/unzipToArrays'
 export { objectToPairs } from './object/objectToPairs'
 export { splitToArrays } from './object/splitToArrays'
 export { mergeSkipNullish } from './object/mergeSkipNullish'
+export { flattenObject } from './object/flattenObject'
 
 export { difference } from './array/difference'
 export { intersection } from './array/intersection'
@@ -129,7 +130,14 @@ export type {
   DataUnit,
   PseudoArray,
   Nullish,
-  SpreadSkipNullish
+  SpreadSkipNullish,
+  ArrayIndexes,
+  FieldPathComponent,
+  FlattenArrayObject,
+  FlattenObject,
+  UnionToIntersection,
+  IntersectionToObject,
+  FlattenNestObject
 } from './common/types'
 
 export {

--- a/packages/main.ts
+++ b/packages/main.ts
@@ -131,6 +131,7 @@ export type {
   PseudoArray,
   Nullish,
   SpreadSkipNullish,
+  IsAny,
   ArrayIndexes,
   FieldPathComponent,
   FlattenArrayObject,

--- a/packages/object/__test__/flattenObject.test.ts
+++ b/packages/object/__test__/flattenObject.test.ts
@@ -1,0 +1,98 @@
+import { flattenObject } from '../flattenObject'
+import { describe, test, expect } from 'vitest'
+
+describe('flattenObject', () => {
+  test('should flatten a simple nested object', () => {
+    const input = {
+      a: 1,
+      b: {
+        c: 2,
+        d: {
+          e: 3
+        }
+      }
+    }
+    const expected = {
+      a: 1,
+      'b.c': 2,
+      'b.d.e': 3
+    }
+    expect(flattenObject(input)).toEqual(expected)
+  })
+
+  test('should handle arrays correctly', () => {
+    const input = {
+      a: [1, 2, { b: 3 }],
+      c: {
+        d: [4, 5, { e: 6 }]
+      }
+    }
+    const expected = {
+      'a[0]': 1,
+      'a[1]': 2,
+      'a[2].b': 3,
+      'c.d[0]': 4,
+      'c.d[1]': 5,
+      'c.d[2].e': 6
+    }
+    expect(flattenObject(input)).toEqual(expected)
+  })
+
+  test('should handle deeply nested objects and arrays', () => {
+    const input = {
+      a: {
+        b: [1, { c: 2 }, [3, { d: 4 }]]
+      },
+      e: {
+        f: {
+          g: 5
+        }
+      }
+    }
+    const expected = {
+      'a.b[0]': 1,
+      'a.b[1].c': 2,
+      'a.b[2][0]': 3,
+      'a.b[2][1].d': 4,
+      'e.f.g': 5
+    }
+    expect(flattenObject(input)).toEqual(expected)
+  })
+
+  test('should handle empty objects and arrays', () => {
+    const input = {
+      a: {},
+      b: [],
+      c: {
+        d: {},
+        e: []
+      }
+    }
+    const expected = {}
+    expect(flattenObject(input)).toEqual(expected)
+  })
+
+  test('should handle objects with mixed types', () => {
+    const input = {
+      a: 1,
+      b: 'string',
+      c: true,
+      d: null,
+      e: undefined,
+      f: {
+        g: 2,
+        h: 'another string'
+      }
+    }
+    const expected = {
+      a: 1,
+      b: 'string',
+      c: true,
+      d: null,
+      e: undefined,
+      'f.g': 2,
+      'f.h': 'another string'
+    }
+    expect(flattenObject(input)).toEqual(expected)
+  })
+})

--- a/packages/object/flattenObject.ts
+++ b/packages/object/flattenObject.ts
@@ -1,0 +1,38 @@
+import { FlattenNestObject } from '../common/types'
+import { isArray, isNumberString, isObject } from '../main'
+
+/**
+ * Receive an object `obj`, perform a depth-first traversal of the enumerable properties of nested objects, and return a flattened new object where the key is the field path string and the value is the corresponding value.
+ * @template {extends object} T The type of the object to be flattened
+ * @param {T} obj The object to be flattened
+ * @returns {FlattenNestObject<T>}
+ * @version 0.0.4
+ */
+
+export function flattenObject<T extends object>(obj: T) {
+  const ans: Record<string, any> = {}
+  flattenHelper(obj, ans)
+  return ans as FlattenNestObject<T>
+}
+function flattenHelper(
+  currentObj: any,
+  ans: any,
+  prefix: string | number = ''
+) {
+  const keys = Object.keys(currentObj)
+  for (const key of keys) {
+    const value = currentObj[key]
+    const newKey = prefix
+      ? isArray(currentObj) && isNumberString(key)
+        ? `${prefix}[${key}]`
+        : `${prefix}.${key}`
+      : isArray(currentObj) && isNumberString(key)
+        ? `[${key}]`
+        : key
+    if (isObject(value)) {
+      flattenHelper(value, ans, newKey)
+    } else {
+      ans[newKey] = value
+    }
+  }
+}


### PR DESCRIPTION
## Description

- Added the `flattenObject` function to the common utilities.
- Added and exported the following utility types for use with `flattenObject` and related scenarios:
  - `IsAny`
  - `ArrayIndexes`
  - `FieldPathComponent`
  - `FlattenArrayObject`
  - `FlattenObject`
  - `UnionToIntersection`
  - `IntersectionToObject`
  - `FlattenNestObject`
- Fixed a flakiness in the poll test cases caused by too small timer intervals.

## Impact

- New flattenObject function and types improve object flattening capabilities.
- Poll tests are now more stable and reliable.

## Notes

- All related exports are updated in the main entry file.
- No breaking changes.